### PR TITLE
Fix to work with node > v0.4

### DIFF
--- a/lib/require-like.js
+++ b/lib/require-like.js
@@ -23,7 +23,12 @@ module.exports = function requireLike(path, uncached) {
     return Module._resolveFilename(request, parentModule)[1];
   }
 
-  requireLike.paths = require.paths;
+  try {
+    requireLike.paths = require.paths;
+  } catch (e) {
+    //require.paths was deprecated in node v0.5.x
+    //it now throws an exception when called
+  }
   requireLike.main = process.mainModule;
   requireLike.extensions = require.extensions;
   requireLike.cache = require.cache;

--- a/test/integration/test-basics.js
+++ b/test/integration/test-basics.js
@@ -27,10 +27,12 @@ var requireLike = require(common.dir.lib + '/require-like');
   assert.strictEqual(fooPath, common.dir.fixture + '/foo.js');
 })();
 
-(function testPaths() {
-  var myRequire = requireLike(common.dir.fixture + '/bar.js');
-  assert.strictEqual(myRequire.paths, require.paths);
-})();
+if (process.version <= 'v0.5') {
+  (function testPaths() {
+    var myRequire = requireLike(common.dir.fixture + '/bar.js');
+    assert.strictEqual(myRequire.paths, require.paths);
+  })();
+}
 
 (function testMain() {
   var myRequire = requireLike(common.dir.fixture + '/bar.js');


### PR DESCRIPTION
Hi,

I've patched the code to not break when using a version of node that throws exceptions when require.paths is accessed. I haven't attempted anything fancier than just silently swallowing the exception. 

Cheers,
Gareth.
