### PR TITLE
Make resolve work with node v0.6.10

### DIFF
--- a/lib/require-like.js
+++ b/lib/require-like.js
@@ -20,7 +20,10 @@ module.exports = function requireLike(path, uncached) {
 
 
   requireLike.resolve = function(request) {
-    return Module._resolveFilename(request, parentModule)[1];
+    var resolved = Module._resolveFilename(request, parentModule);
+    // Module._resolveFilename returns a string since node v0.6.10,
+    // it used to return an array prior to that
+    return (resolved instanceof Array) ? resolved[1] : resolved;
   }
 
   try {


### PR DESCRIPTION
Test is broken with node v0.6.10

$ make test
[0:00:00 0 0/1 0.0% node test/integration/test-basics.js]

  node.js:201
          throw e; // process.nextTick error, or 'error' event on first tick
                ^
  AssertionError: "h" === "/home/dev/workspace/node-require-like/test/fixture/foo.js"
      at testResolve (/home/dev/workspace/node-require-like/test/integration/test-basics.js:27:10)
      at Object.<anonymous> (/home/dev/workspace/node-require-like/test/integration/test-basics.js:28:2)
      at Module._compile (module.js:441:26)
      at Object..js (module.js:459:10)
      at Module.load (module.js:348:31)
      at Function._load (module.js:308:12)
      at Array.0 (module.js:479:10)
      at EventEmitter._tickCallback (node.js:192:40)

[0:00:00 1 0/1 100.0% node test/integration/test-basics.js]
make: **\* [test] Error 1

This problem is caused by this commit https://github.com/joyent/node/commit/840229a8251955d2b791928875f36d35127dcad0#lib/module.js (as pointed by itay on https://github.com/felixge/node-sandboxed-module/issues/5) where Module._resolveFilename no longer returns an array.

I've tested this patch against node v0.4.7, v0.6.9, and v0.6.10 .
